### PR TITLE
update ci

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ clone_folder: c:\projects\sphinx-docfx-yaml
 
 install:
   # Nuget
-  - nuget install uref -Prerelease -Source https://www.myget.org/F/docfx-dev/api/v3/index.json -ExcludeVersion -OutputDirectory c:\projects
-  - nuget install docfx.console -Prerelease -Source https://www.myget.org/F/docfx-dev/api/v3/index.json -ExcludeVersion -OutputDirectory c:\projects
+  - nuget install uref -Source https://www.myget.org/F/docfx/api/v3/index.json -ExcludeVersion -OutputDirectory c:\projects
+  - nuget install docfx.console -Source https://www.myget.org/F/docfx/api/v3/index.json -ExcludeVersion -OutputDirectory c:\projects
   # Python
   - ps: (new-object net.webclient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'C:/get-pip.py')
   - "%PYTHON%/python.exe C:/get-pip.py"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extra_setup = dict(
 install_requires=[
     'PyYAML',
     'wheel==0.24.0',
-    'sphinx',
+    'sphinx==1.5.5',
     'unidecode',
 ],
 setup_requires=['pytest-runner'],


### PR DESCRIPTION
Use docfx release version as the uref plugin goes stable.
Fix Sphinx version as v1.6.1 has some breaking changes.