### PR TITLE
bug fix: code sample is missing content

### DIFF
--- a/docfx_yaml/writer.py
+++ b/docfx_yaml/writer.py
@@ -802,7 +802,7 @@ class MarkdownTranslator(nodes.NodeVisitor):
         self.end_state(wrap=False)
 
     def visit_doctest_block(self, node):
-        self.add_text('```')
+        self.add_text(self.nl + '```')
         self.new_state(0)
 
     def depart_doctest_block(self, node):


### PR DESCRIPTION
Fix bug:
in https://docs.microsoft.com/en-us/python/api/cntk.ops.functions.function?view=cntk-py-2.0 
"d = c * 5 C.combine" code block is messed up.