### PR TITLE
bug fix: SYSTEM MESSAGE in Python API doc generation output

### DIFF
--- a/docfx_yaml/writer.py
+++ b/docfx_yaml/writer.py
@@ -25,6 +25,17 @@ from docutils.utils import column_width
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels
 
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
 
 class TextWrapper(textwrap.TextWrapper):
     """Custom subclass that uses a different word separator regex."""
@@ -999,10 +1010,7 @@ class MarkdownTranslator(nodes.NodeVisitor):
         self.add_text('<<')
 
     def visit_system_message(self, node):
-        if self.keep_warnings:
-            self.new_state(0)
-            self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
-            self.end_state()
+        print(bcolors.WARNING + "System message warnings: %s" % node.astext() + bcolors.ENDC)
         raise nodes.SkipNode
 
     def visit_comment(self, node):

--- a/docfx_yaml/writer.py
+++ b/docfx_yaml/writer.py
@@ -189,7 +189,6 @@ class MarkdownTranslator(nodes.NodeVisitor):
         self.sectionlevel = 0
         self.lineblocklevel = 0
         self.table = None
-        self.keep_warnings = builder.config.keep_warnings
 
     def add_text(self, text):
         self.states[-1].append((-1, text))

--- a/docfx_yaml/writer.py
+++ b/docfx_yaml/writer.py
@@ -178,6 +178,7 @@ class MarkdownTranslator(nodes.NodeVisitor):
         self.sectionlevel = 0
         self.lineblocklevel = 0
         self.table = None
+        self.keep_warnings = builder.config.keep_warnings
 
     def add_text(self, text):
         self.states[-1].append((-1, text))
@@ -998,9 +999,10 @@ class MarkdownTranslator(nodes.NodeVisitor):
         self.add_text('<<')
 
     def visit_system_message(self, node):
-        self.new_state(0)
-        self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
-        self.end_state()
+        if self.keep_warnings:
+            self.new_state(0)
+            self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
+            self.end_state()
         raise nodes.SkipNode
 
     def visit_comment(self, node):


### PR DESCRIPTION
according to: http://sphinx-doc-zh.readthedocs.io/en/latest/config.html, 
the system_message can be skipped by default.
But as we used writer.py which based on
https://github.com/sphinx-doc/sphinx/blob/master/sphinx/writers/text.py
we need explicitly skip it.
