### PR TITLE
Fix a bug where the py:class can be None

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -815,7 +815,7 @@ def missing_reference(app, env, node, contnode):
                 fields = (module, reftarget)
             else:
                 fields = (module, node['py:class'], reftarget)
-            reftarget = '.'.join(fields)
+            reftarget = '.'.join(field for field in fields if field is not None)
 
         return make_refnode(app.builder, refdoc, reftarget, '', contnode)
 


### PR DESCRIPTION
The bug happens when you try to import function from other module into current package by using `__init__.py`  .  Those imported functions will somehow have py:class = None.