### PR TITLE
bump sphinx dependency to 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extra_setup = dict(
 install_requires=[
     'PyYAML',
     'wheel>=0.24.0',
-    'sphinx==1.5.5',
+    'sphinx==3.0.0',
     'unidecode',
 ],
 setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require=['pytest', 'mock'],
 
 setup(
     name='sphinx-docfx-yaml',
-    version='1.2.72',
+    version='1.2.73',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='https://github.com/ericholscher/sphinx-docfx-yaml',


### PR DESCRIPTION
This bug:
https://github.com/sphinx-doc/sphinx/issues/5076

Was fixed in this PR:
https://github.com/sphinx-doc/sphinx/pull/5119

And released with Sphinx 3.0.0:
https://pypi.org/project/Sphinx/3.0.0/