### PR TITLE
Handle Keyword Parameters

### DIFF
--- a/docfx_yaml/monkeypatch.py
+++ b/docfx_yaml/monkeypatch.py
@@ -259,7 +259,7 @@ def patch_docfields(app):
                     returnvalue_ret = transform_node(content[1][0])
                     if returnvalue_ret:
                         data['return']['description'] = returnvalue_ret.strip(" \n\r\t")
-                if fieldtype.name in ['parameter', 'variable']:
+                if fieldtype.name in ['parameter', 'variable', 'keyword']:
                     for field, node_list in content:
                         _id = field
                         _description = transform_node(node_list[0])
@@ -269,7 +269,7 @@ def patch_docfields(app):
                             _type = None
 
                         _para_types = []
-                        if fieldtype.name == 'parameter':
+                        if fieldtype.name == 'parameter' or fieldtype.name == 'keyword':
                             if _type:
                                 # Support or in parameter type
                                 for _s_type in re.split('[ \n]or[ \n]', _type):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require=['pytest', 'mock'],
 
 setup(
     name='sphinx-docfx-yaml',
-    version='1.2.73',
+    version='1.2.74',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='https://github.com/ericholscher/sphinx-docfx-yaml',


### PR DESCRIPTION
[Test Build Consuming docfx-yaml from my fork via git+https](https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=150344&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=70b92200-87db-50c8-35f9-975ba5f9e5b7)
[Output](https://github.com/MicrosoftDocs/azure-docs-sdk-python/tree/smoke-test-preview-docfx)

Waiting for publishing to complete to review it on review.docs.ms. @joelmartinez other than providing an easy diff between the original and new intermediate yml output, what other testing do you look for here?
