### PR TITLE
Swap to use getfullargspec instead of getargspec

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -278,7 +278,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
     args = []
     try:
         if _type in [METHOD, FUNCTION]:
-            argspec = inspect.getargspec(obj) # noqa
+            argspec = inspect.getfullargspec(obj) # noqa
             for arg in argspec.args:
                 args.append({'id': arg})
             if argspec.defaults:
@@ -289,8 +289,8 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                     # Match the defaults with the count
                     if 'object at 0x' not in str(default):
                         args[len(args) - cut_count + count]['defaultValue'] = str(default)
-    except Exception:
-        print("Can't get argspec for {}: {}".format(type(obj), name))
+    except Exception as e:
+        print("Can't get argspec for {}: {}. Exception: {}".format(type(obj), name, e))
 
     if name in app.env.docfx_signature_funcs_methods:
         sig = app.env.docfx_signature_funcs_methods[name]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require=['pytest', 'mock'],
 
 setup(
     name='sphinx-docfx-yaml',
-    version='1.2.74',
+    version='1.2.75',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='https://github.com/ericholscher/sphinx-docfx-yaml',


### PR DESCRIPTION
[Example CI Run](https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=172001&view=results)
[Output](https://github.com/MicrosoftDocs/azure-docs-sdk-python/tree/check-kwarg-output)

I ran another CI run to grab original output so we can easily compare [here.](https://github.com/MicrosoftDocs/azure-docs-sdk-python/compare/check-original-output...check-kwarg-output)

Waiting for validation of published docs, but the generated yaml changes definitely look good on the outset.

@joelmartinez take a look?