### PR TITLE
Optional Args shouldn't be labelled as "Required"

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -57,6 +57,8 @@ REFFUNCTION = 'func'
 INITPY = '__init__.py'
 REF_PATTERN = ':(py:)?(func|class|meth|mod|ref):`~?[a-zA-Z_\.<> ]*?`'
 
+import pdb
+
 
 def build_init(app):
     """
@@ -634,6 +636,8 @@ def build_finished(app, exception):
 
                     if 'parameters' in obj['syntax'] and obj['type'] == 'method':	
                         for args in obj['syntax']['parameters']:
+                            if "client_secret" in obj['uid']:
+                                print(args)
                             if 'isRequired' not in args and 'defaultValue' not in args:
                                 args['isRequired'] = True
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -632,11 +632,6 @@ def build_finished(app, exception):
                     if merged_params:
                         obj['syntax']['parameters'] = merged_params
 
-                    if 'parameters' in obj['syntax'] and obj['type'] == 'method':
-                        for args in obj['syntax']['parameters']:
-                            if 'defaultValue' not in args:
-                                args['isRequired'] = True
-
                     # Raise up summary
                     if 'summary' in obj['syntax'] and obj['syntax']['summary']:
                         obj['summary'] = obj['syntax'].pop('summary').strip(" \n\r\r")

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -634,7 +634,7 @@ def build_finished(app, exception):
 
                     if 'parameters' in obj['syntax'] and obj['type'] == 'method':	
                         for args in obj['syntax']['parameters']:
-                            if 'isRequired' not in args:
+                            if 'isRequired' not in args and 'defaultValue' not in args:
                                 args['isRequired'] = True
 
                     # Raise up summary

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -632,6 +632,11 @@ def build_finished(app, exception):
                     if merged_params:
                         obj['syntax']['parameters'] = merged_params
 
+                    if 'parameters' in obj['syntax'] and obj['type'] == 'method':	
+                        for args in obj['syntax']['parameters']:	
+                            if 'isRequired' not in args:	
+                                args['isRequired'] = True
+
                     # Raise up summary
                     if 'summary' in obj['syntax'] and obj['syntax']['summary']:
                         obj['summary'] = obj['syntax'].pop('summary').strip(" \n\r\r")

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -633,8 +633,8 @@ def build_finished(app, exception):
                         obj['syntax']['parameters'] = merged_params
 
                     if 'parameters' in obj['syntax'] and obj['type'] == 'method':	
-                        for args in obj['syntax']['parameters']:	
-                            if 'isRequired' not in args:	
+                        for args in obj['syntax']['parameters']:
+                            if 'isRequired' not in args:
                                 args['isRequired'] = True
 
                     # Raise up summary

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -57,8 +57,6 @@ REFFUNCTION = 'func'
 INITPY = '__init__.py'
 REF_PATTERN = ':(py:)?(func|class|meth|mod|ref):`~?[a-zA-Z_\.<> ]*?`'
 
-import pdb
-
 
 def build_init(app):
     """
@@ -636,8 +634,6 @@ def build_finished(app, exception):
 
                     if 'parameters' in obj['syntax'] and obj['type'] == 'method':	
                         for args in obj['syntax']['parameters']:
-                            if "client_secret" in obj['uid']:
-                                print(args)
                             if 'isRequired' not in args and 'defaultValue' not in args:
                                 args['isRequired'] = True
 

--- a/docfx_yaml/monkeypatch.py
+++ b/docfx_yaml/monkeypatch.py
@@ -304,7 +304,7 @@ def patch_docfields(app):
 
                                     _para_types.append(_s_type)
 
-                            _data = make_param(_id=_id, _type=_para_types, _description=_description, _required = True)
+                            _data = make_param(_id=_id, _type=_para_types, _description=_description)
                             data['variables'].append(_data)
 
                     ret_list = extract_exception_desc(field_object)

--- a/docfx_yaml/monkeypatch.py
+++ b/docfx_yaml/monkeypatch.py
@@ -160,13 +160,17 @@ def patch_docfields(app):
             'references': [],
         }
 
-        def make_param(_id, _description, _type=None):
+        def make_param(_id, _description, _type=None, _required=None):
             ret = {
                 'id': _id,
-                'description': _description.strip(" \n\r\t"),
+                'description': _description.strip(" \n\r\t")
             }
             if _type:
                 ret['type'] = _type
+
+            if _required is not None:
+                ret['isRequired'] = _required
+
             return ret
 
         def transform_para(para_field):
@@ -282,8 +286,11 @@ def patch_docfields(app):
 
                                     _para_types.append(_s_type)
 
-                            _data = make_param(_id=_id, _type=_para_types, _description=_description)
+
+
+                            _data = make_param(_id=_id, _type=_para_types, _description=_description, _required=False if fieldtype.name == 'keyword' else True)
                             data['parameters'].append(_data)
+
                         if fieldtype.name == 'variable':
                             if _type:
                                 # Support or in variable type

--- a/docfx_yaml/monkeypatch.py
+++ b/docfx_yaml/monkeypatch.py
@@ -304,7 +304,7 @@ def patch_docfields(app):
 
                                     _para_types.append(_s_type)
 
-                            _data = make_param(_id=_id, _type=_para_types, _description=_description)
+                            _data = make_param(_id=_id, _type=_para_types, _description=_description, _required = True)
                             data['variables'].append(_data)
 
                     ret_list = extract_exception_desc(field_object)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require=['pytest', 'mock'],
 
 setup(
     name='sphinx-docfx-yaml',
-    version='1.2.75',
+    version='1.2.76',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='https://github.com/ericholscher/sphinx-docfx-yaml',


### PR DESCRIPTION
Oh man it was frustrating to locate where `isRequired` was actually set. 

I really should have grepped for the name of that setting, would have been a lot faster.